### PR TITLE
feat: Add support user event and mangement.

### DIFF
--- a/plugin/pixela.vim
+++ b/plugin/pixela.vim
@@ -34,11 +34,8 @@ endfunction
 
 augroup vim-pixela
   autocmd!
-  if !v:vim_did_enter
-    autocmd VimEnter * call s:start()
-  else
-    autocmd User VimPixela call s:start()
-  endif
+  autocmd VimEnter * call s:start()
+  autocmd User VimPixela call s:start()
 augroup END
 
 command! VimPixela call s:browser()

--- a/plugin/pixela.vim
+++ b/plugin/pixela.vim
@@ -19,6 +19,9 @@ function! s:start()
   \  printf('https://pixe.la/v1/users/%s/graphs/vim-pixela/increment', user),
   \  '-H', printf('X-USER-TOKEN:%s', token),
   \  '-H', 'Content-Length:0'], opts)
+
+  " remove event
+  autocmd! vim-pixela
 endfunction
 
 function! s:browser()
@@ -29,8 +32,13 @@ function! s:browser()
   call openbrowser#open(printf('https://pixe.la/v1/users/%s/graphs/vim-pixela', user))
 endfunction
 
-if !v:vim_did_enter
-  au VimEnter * call s:start()
-endif
+augroup vim-pixela
+  autocmd!
+  if !v:vim_did_enter
+    autocmd VimEnter * call s:start()
+  else
+    autocmd User VimPixela call s:start()
+  endif
+augroup END
 
 command! VimPixela call s:browser()


### PR DESCRIPTION
Add User Event and fix event management.

* Use `vim-pixela` group
* Always set `VimEnter` event
* Add new event `User VimPixela` and call `s:start()`
* When process `s:start()`, erase `vim-pixela` group

If lazy loading vim-pixleta, user invoke `doautocmd User VimPixela` work fine.
And basically only once process.