### PR TITLE
fix: suppress output

### DIFF
--- a/plugin/pixela.vim
+++ b/plugin/pixela.vim
@@ -16,6 +16,7 @@ function! s:start()
   endif
   let s:job = job_start([
   \  'curl', '-v', '-X', 'PUT',
+  \  '-o', printf('%s', has('win32') ? 'nul' : '/dev/null'),
   \  printf('https://pixe.la/v1/users/%s/graphs/vim-pixela/increment', user),
   \  '-H', printf('X-USER-TOKEN:%s', token),
   \  '-H', 'Content-Length:0'], opts)


### PR DESCRIPTION
(`curl` default was changed?)

Now `curl` command save `increment` file and write  response body.

This PR suppress output.
Use `nul` or `/dev/null`.

---

test

```
curl 7.81.0 (x86_64-w64-mingw32) libcurl/7.81.0 OpenSSL/1.1.1m (Schannel) zlib/1.2.11 brotli/1.0.9 zstd/1.5.2 libidn2/2.3.1 libssh2/1.10.0 nghttp2/1.46.0
Release-Date: 2022-01-05
Protocols: dict file ftp ftps gopher gophers http https imap imaps ldap ldaps mqtt pop3 pop3s rtsp scp sftp smb smbs smtp smtps telnet tftp
Features: alt-svc AsynchDNS brotli HSTS HTTP2 HTTPS-proxy IDN IPv6 Kerberos Largefile libz MultiSSL NTLM SPNEGO SSL SSPI TLS-SRP zstd
```

Git for Windows (git version 2.35.1.windows.2) bundle `curl`